### PR TITLE
JSON (un)marshalling fix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+{ pkgs ? (import <nixpkgs> {}), lib ? (import <nixpkgs/lib>) }:
+pkgs.buildGoModule rec {
+  name = "go-schemaless";
+  src = ./. ;
+  vendorSha256 = "83hT7SIZlQ4EPdzA5jN+so59a5yIcBrnBREs4EfpuUc=";
+}

--- a/examples/apiserver/build
+++ b/examples/apiserver/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 rm -rf sandbox
 mkdir sandbox

--- a/examples/apiserver/run
+++ b/examples/apiserver/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd sandbox
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1622445595,
+        "narHash": "sha256-m+JRe6Wc5OZ/mKw2bB3+Tl0ZbtyxxxfnAWln8Q5qs+Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7d706970d94bc5559077eb1a6600afddcd25a7c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1622922048,
+        "narHash": "sha256-nTyKxe0n7l/4HSmYaIN+63WQrvHrTJY6drSwP7bMqhU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5de44c15758465f8ddf84d541ba300b48e56eda4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = self:
+  self.flake-utils.lib.eachDefaultSystem (system:
+  let
+    pkgs = self.nixpkgs.legacyPackages.${system};
+    lib = self.nixpkgs.lib;
+  in
+  rec {
+    packages = self.flake-utils.lib.flattenTree {
+      go-schemaless = (import ./.) { inherit pkgs lib;};
+    };
+    defaultPackage = packages.go-schemaless;
+    devShell = (import ./shell.nix) { inherit pkgs lib; };
+  }
+  );
+}

--- a/models/cell.go
+++ b/models/cell.go
@@ -19,13 +19,13 @@ package models
 // https://eng.uber.com/schemaless-part-one/
 //
 type Cell struct {
-	Type       string `json:"omitempty"`
-	AddedAt    uint64 `json:"omitempty"`
-	RowKey     string `json:"omitempty"` // UUID, typically, but could be anything
-	ColumnName string `json:"omitempty"` // The actual column name for the individual Body blob
-	RefKey     int64  `json:"omitempty"` // for versioning or sorting cells in a list
-	Body       string `json:"omitempty"` // Uber chose JSON inside MessagePack'd LZ4 blobs, we store raw JSON
-	CreatedAt  uint64 `json:"omitempty"`
+	Type       string `json:",omitempty"`
+	AddedAt    uint64 `json:",omitempty"`
+	RowKey     string `json:",omitempty"` // UUID, typically, but could be anything
+	ColumnName string `json:",omitempty"` // The actual column name for the individual Body blob
+	RefKey     int64  `json:",omitempty"` // for versioning or sorting cells in a list
+	Body       string `json:",omitempty"` // Uber chose JSON inside MessagePack'd LZ4 blobs, we store raw JSON
+	CreatedAt  uint64 `json:",omitempty"`
 }
 
 // NewCell constructs a Cell structure with the minimum parameters necessary:

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? (import <nixpkgs> {}), lib ? (import <nixpkgs/lib>) }:
+pkgs.mkShell {
+  # nativeBuildInputs is usually what you want -- tools you need to run
+  nativeBuildInputs = with pkgs.buildPackages; [ go protobuf ];
+}


### PR DESCRIPTION
The oft-encountered mistake of `json:"omitempty"` instead of `json:",omitempty"` was discovered in this repo!

**Note**: This branch is actually based on #21 but I can't figure out how to make a PR to this repository using a base branch from my fork. So, I would recommend looking at this once #21 is merged (assuming it will be merged).